### PR TITLE
Refactor metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 import json
 
 import cityflow as cf
+from matplotlib import pyplot as plt
 
+from metrics.metrics import CompletedJourneysMetric, WaitTimeMetric
 from simulation_builder.flows import graph_to_flow, FlowStrategy, RandomFlowStrategy, CustomEndpointFlowStrategy
 from simulation_builder.roadnets import graph_to_roadnet
 from simulation_builder.graph import Graph, spiral_graph
@@ -28,6 +30,12 @@ if __name__ == "__main__":
     with open("cityflow_config/flows/auto_flow.json", 'w') as f:
         f.write(json.dumps(flow, indent=4))
 
+    m = WaitTimeMetric()
     eng = cf.Engine("cityflow_config/config.json", thread_num=1)
     for _ in range(1000):
         eng.next_step()
+        m.update(eng)
+
+    print(m.report())
+    plt.plot(m.report().data)
+    plt.show()

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -1,0 +1,55 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from numbers import Number
+from typing import List
+
+
+@dataclass
+class Report:
+    aggregate: Number
+    data: List[Number]
+
+
+class Metric(ABC):
+    @abstractmethod
+    def update(self, eng):
+        pass
+
+    @abstractmethod
+    def report(self) -> Report:
+        pass
+
+
+class CompletedJourneysMetric(Metric):
+    def __init__(self):
+        self._prev_step = set()
+        self._completed_journeys = [0]
+
+    def update(self, eng):
+        curr_step = set(eng.get_vehicles(include_waiting=False))
+        self._completed_journeys.append(len(self._prev_step - curr_step) + self._completed_journeys[-1])
+        self._prev_step = curr_step
+
+    def report(self) -> Report:
+        return Report(self._completed_journeys[-1], self._completed_journeys)
+
+
+class WaitTimeMetric(Metric):
+    """
+    Reports the overall average waiting time, and the proportion of cars waiting at each time step.
+    """
+    def __init__(self):
+        self._waiting_vehicles = []
+        self._total_vehicles = []
+
+    def update(self, eng):
+        vehicles = eng.get_vehicles(include_waiting=False)
+        wait_time = sum([float(eng.get_vehicle_info(v)['speed']) < 0.1 for v in vehicles])
+        self._total_vehicles.append(len(vehicles))
+        self._waiting_vehicles.append(wait_time)
+
+    def report(self) -> Report:
+        total_average = sum(self._waiting_vehicles) / sum(self._total_vehicles)
+        proportion_waiting = [wait / total if total > 0 else 0 for wait, total in
+                              zip(self._waiting_vehicles, self._total_vehicles)]
+        return Report(total_average, proportion_waiting)

--- a/simulation_builder/roadnets.py
+++ b/simulation_builder/roadnets.py
@@ -7,6 +7,11 @@ from simulation_builder.graph import Graph, Road
 def graph_to_roadnet(g: Graph, traffic_light_phases: Optional[Dict] = None, intersection_width=50, lane_width=4,
                      lane_speed=20) -> Dict:
     """
+    Params:
+        g: A graph specifying road connections
+        traffic_light_phases: An (optional) dictionary, mapping each intersection to a list of traffic light phase
+                              timings.
+
     Returns:
          A dictionary representing the roadnet generated from g.
     """


### PR DESCRIPTION
This adds the following:

- A **report class** to standardise what metrics return
- A standardised **interface for metrics** - this defines an `update()` and `report()` method which all metrics must implement
- Example metrics for 
  - Computing the **number of completed journeys** (returns the total number and the number of journeys completed at each time step) 
  - Computing **wait times** (returns total average wait time and the proportion of cars waiting at each time step).

Please ask if you're unsure of how the new classes work.